### PR TITLE
General changes to graph and chat behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ ollama/
 .DS_Store
 kg/
 llm_worker_config.toml
+
+# Remove auto-generated pycache folder
+src/studio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
   "python-socketio>=5.15.0,<6", 
   "langchain-openai>=1.1.3,<2", 
   "mcp-use>=1.5.0,<2", 
-  "langchain>=1.1.3,<2",
+  "langchain>=1.1.3,<2", 
+  "typing-extensions",
 ]
 
 # ====================================

--- a/scepa_tools.json
+++ b/scepa_tools.json
@@ -1,7 +1,7 @@
 {
 "mcpServers": {
-	"paper": {
-		"url": "http://127.0.0.1:8000/sse"
-	}
+        "paper": {
+                "url": "https://kp.mads-han.src.surf-hosted.nl/sse"
+        }
 }
 }

--- a/src/backend/endpoints/chat.py
+++ b/src/backend/endpoints/chat.py
@@ -13,6 +13,7 @@ from backend.endpoints.graph import (
     user_graph_contexts,
     SUBNODES,
     prefetch_subnode,
+    _default_user_graph_context
 )
 
 from src.backend.utility.chat_util import (
@@ -72,7 +73,8 @@ async def connect(sid, environ, auth):
 
     user_id = user["sub"]
     bind_user(user_id, sid)
-
+    user_graph_contexts[user_id] = _default_user_graph_context()
+    
     print(f"✓ Socket connected: {sid} user={user_id}")
 
 

--- a/src/backend/endpoints/chat.py
+++ b/src/backend/endpoints/chat.py
@@ -110,7 +110,7 @@ async def send_message(sid, data):
         # ALWAYS clear the flag, even if we error/return early
         try:
             # Resolve same vs new question
-            if user_msg.lower() == "no":
+            if user_msg.lower() == "yes":
                 question = latest_question
             else:
                 ctx["previous_question"] = latest_question
@@ -124,7 +124,7 @@ async def send_message(sid, data):
 
             # Cached answer path (only safe if question unchanged)
             prefetched = ctx.get("prefetched", {}).get(selected_subnode)
-            if prefetched and user_msg.lower() == "no":
+            if prefetched and user_msg.lower() == "yes":
                 await push_chat_message_stream(
                     user_id,
                     "on_chat_model_stream",

--- a/src/backend/endpoints/chat.py
+++ b/src/backend/endpoints/chat.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import time
 from collections import defaultdict
@@ -11,15 +10,14 @@ from fastapi import APIRouter
 from backend.config import LLM_WORKER_URL, LLM_WORKER_PORT, BASE_URL
 from backend.endpoints.graph import (
     user_graph_contexts,
-    SUBNODES,
-    prefetch_subnode,
     _default_user_graph_context
 )
-
+from backend.endpoints.graph import fetch_subnode_stream
 from src.backend.utility.chat_util import (
     register_socketio,
     bind_user,
     unbind_sid,
+    push_chat_message_stream,
     sid_connections,
 )
 
@@ -93,24 +91,77 @@ async def send_message(sid, data):
     if not user_id:
         return
 
-    user_msg = data.get("message", "").strip()
+    user_msg = (data.get("message") or "").strip()
     if not user_msg:
         return
 
     session = user_sessions.setdefault(user_id, {"history": []})
-    ctx = user_graph_contexts.setdefault(
-        user_id,
-        {
-            "latest_question": None,
-            "selected_subnode": "root",
-            "pending": {},
-            "prefetched": {},
-        },
-    )
+    ctx = user_graph_contexts[user_id]
 
+    selected_subnode = ctx.get("selected_subnode", "root")
+    latest_question = ctx.get("latest_question")
+    dialogue_state_asked = bool(ctx.get("dialogue_state_asked", False))
+
+    # --------------------------------------------------
+    # DIALOGUE STATE HANDLING (root + subnodes unified)
+    # The user is answering: "new question or reuse the same one?"
+    # --------------------------------------------------
+    if dialogue_state_asked:
+        # ALWAYS clear the flag, even if we error/return early
+        try:
+            # Resolve same vs new question
+            if user_msg.lower() == "no":
+                question = latest_question
+            else:
+                ctx["previous_question"] = latest_question
+                question = user_msg
+                ctx["latest_question"] = question
+
+            # If no previous question exists, treat input as the question
+            if not question:
+                question = user_msg
+                ctx["latest_question"] = question
+
+            # Cached answer path (only safe if question unchanged)
+            prefetched = ctx.get("prefetched", {}).get(selected_subnode)
+            if prefetched and user_msg.lower() == "no":
+                await push_chat_message_stream(
+                    user_id,
+                    "on_chat_model_stream",
+                    prefetched,
+                    selected_subnode,
+                )
+                await push_chat_message_stream(
+                    user_id,
+                    "done",
+                    prefetched,
+                    selected_subnode,
+                )
+                return
+
+            # Fresh LLM path (this function should stream + emit done itself)
+
+            await fetch_subnode_stream(user_id, question, selected_subnode)
+            await push_chat_message_stream(
+                    user_id,
+                    "done",
+                    prefetched,
+                    selected_subnode,
+                )
+            return
+
+        finally:
+            ctx["dialogue_state_asked"] = False
+
+    # --------------------------------------------------
+    # NORMAL ROOT WORKFLOW (user asked a new question in chat)
+    # --------------------------------------------------
     session["history"].append({"role": "user", "message": user_msg})
+
+    ctx["previous_question"] = ctx.get("latest_question")
     ctx["latest_question"] = user_msg
     ctx["selected_subnode"] = "root"
+    ctx["dialogue_state_asked"] = False
 
     synthetic_prompt = (
         "SYSTEM META-INSTRUCTION:\n"
@@ -135,12 +186,9 @@ async def send_message(sid, data):
         ) as resp:
 
             if resp.status_code != 200:
-                await sio.emit(
-                    "message",
-                    {"role": "chatbot", "content": "❌ Error: worker unavailable"},
-                    to=sid,
-                )
-                await sio.emit("done", to=sid)
+                err = "❌ Error: worker unavailable"
+                await push_chat_message_stream(user_id, "on_chat_model_stream", err, "root")
+                await push_chat_message_stream(user_id, "done", err, "root")
                 return
 
             async for line in resp.aiter_lines():
@@ -148,7 +196,6 @@ async def send_message(sid, data):
                     continue
 
                 raw = line.removeprefix("data:").strip()
-
                 if raw == "[DONE]":
                     break
 
@@ -158,56 +205,28 @@ async def send_message(sid, data):
                     continue
 
                 event_type = payload.get("type")
-                event_data = payload.get("data")
+                event_data = payload.get("data") or ""
 
-                # Always forward raw events
-                await sio.emit(
-                    "event",
-                    {
-                        "type": event_type,
-                        "data": event_data,
-                        "timestamp": payload.get("timestamp"),
-                    },
-                    to=sid,
-                )
+                # Forward events (tool/status/etc.) to frontend event channel
+                # NOTE: your push_chat_message_stream will emit these via "event"
+                if event_type != "on_chat_model_stream":
+                    await push_chat_message_stream(user_id, event_type, event_data, "root")
+                    continue
 
-                # ALSO emit chat messages for chat UI
-                if event_type == "on_chat_model_stream" and event_data:
-                    await sio.emit(
-                        "message",
-                        {
-                            "role": "chatbot",
-                            "content": event_data,
-                        },
-                        to=sid,
+                # Stream tokens to chat UI
+                if event_data:
+                    await push_chat_message_stream(
+                        user_id,
+                        "on_chat_model_stream",
+                        event_data,
+                        "root",
                     )
                     full_response += event_data
 
-
     # --------------------------------------------------
-    # FINALIZE RESPONSE
+    # FINALIZE ROOT RESPONSE
     # --------------------------------------------------
-    session["history"].append(
-        {"role": "assistant", "message": full_response}
-    )
+    session["history"].append({"role": "assistant", "message": full_response})
+    ctx.setdefault("prefetched", {})["root"] = full_response
 
-    ctx["prefetched"]["root"] = full_response
-
-    await sio.emit(
-        "done",
-        {"full_response": full_response},
-        to=sid,
-    )
-
-    # --------------------------------------------------
-    # BACKGROUND PREFETCH
-    # --------------------------------------------------
-    for subnode in SUBNODES:
-        if subnode not in ctx["pending"] and subnode not in ctx["prefetched"]:
-            ctx["pending"][subnode] = asyncio.create_task(
-                prefetch_subnode(
-                    user_id=user_id,
-                    question=user_msg,
-                    subnode=subnode,
-                )
-            )
+    await push_chat_message_stream(user_id, "done", full_response, "root")

--- a/src/backend/endpoints/chat.py
+++ b/src/backend/endpoints/chat.py
@@ -99,59 +99,46 @@ async def send_message(sid, data):
     ctx = user_graph_contexts[user_id]
 
     selected_subnode = ctx.get("selected_subnode", "root")
-    latest_question = ctx.get("latest_question")
     dialogue_state_asked = bool(ctx.get("dialogue_state_asked", False))
+    prefetched = (ctx.get("prefetched") or {}).get(selected_subnode)
 
-    # --------------------------------------------------
-    # DIALOGUE STATE HANDLING (root + subnodes unified)
-    # The user is answering: "new question or reuse the same one?"
-    # --------------------------------------------------
     if dialogue_state_asked:
-        # ALWAYS clear the flag, even if we error/return early
         try:
-            # Resolve same vs new question
             if user_msg.lower() == "yes":
-                question = latest_question
+                # Use prefetched if available
+                if prefetched:
+                    await push_chat_message_stream(
+                        user_id,
+                        "on_chat_model_stream",
+                        prefetched,
+                        selected_subnode,
+                    )
+                    await push_chat_message_stream(
+                        user_id,
+                        "done",
+                        prefetched,
+                        selected_subnode,
+                    )
+                    return
+
+                question = ctx.get("latest_question") or ctx.get("previous_question")
             else:
-                ctx["previous_question"] = latest_question
-                question = user_msg
-                ctx["latest_question"] = question
-
-            # If no previous question exists, treat input as the question
-            if not question:
-                question = user_msg
-                ctx["latest_question"] = question
-
-            # Cached answer path (only safe if question unchanged)
-            prefetched = ctx.get("prefetched", {}).get(selected_subnode)
-            if prefetched and user_msg.lower() == "yes":
-                await push_chat_message_stream(
-                    user_id,
-                    "on_chat_model_stream",
-                    prefetched,
-                    selected_subnode,
-                )
-                await push_chat_message_stream(
-                    user_id,
-                    "done",
-                    prefetched,
-                    selected_subnode,
-                )
-                return
-
-            # Fresh LLM path (this function should stream + emit done itself)
+                ctx["latest_question"] = user_msg
+                ctx["prefetched"] = {}
+                question = ctx["latest_question"]
 
             await fetch_subnode_stream(user_id, question, selected_subnode)
             await push_chat_message_stream(
                     user_id,
                     "done",
-                    prefetched,
+                    ctx.get("prefetched", {}).get(selected_subnode),
                     selected_subnode,
                 )
             return
 
         finally:
             ctx["dialogue_state_asked"] = False
+
 
     # --------------------------------------------------
     # NORMAL ROOT WORKFLOW (user asked a new question in chat)

--- a/src/backend/endpoints/graph.py
+++ b/src/backend/endpoints/graph.py
@@ -25,19 +25,6 @@ SUBNODE_MAP = {
 
 SUBNODES = list(SUBNODE_MAP.values())
 
-def strip_think(text: str) -> str:
-    while True:
-        start = text.find("<think>")
-        if start == -1:
-            break
-        end = text.find("</think>", start)
-        if end == -1:
-            text = text[:start]
-            break
-        text = text[:start] + text[end + len("</think>"):]
-    return text.strip()
-
-
 # =====================================================
 # Per-user Graph Context
 # =====================================================
@@ -127,55 +114,6 @@ async def fetch_subnode_stream(user_id: str, question: str, subnode: str):
     except Exception as e:
         print(f"[PREFETCH ERROR - {subnode}] {e}")
 
-async def prefetch_subnode(user_id: str, question: str, subnode: str):
-    """
-    Prefetches a subnode answer from the LLM worker.
-    - Saves result to user_graph_contexts[user_id]["prefetched"]
-    - If the user is viewing that subnode, pushes it immediately.
-    """
-    ctx = user_graph_contexts[user_id]
-
-    try:
-        # Build prefetch prompt
-        prompt = (
-            "SYSTEM META-INSTRUCTION:\n"
-            "If relevant, use the `paper_search` MCP tool to identify scientific "
-            "literature or studies relevant to the question.\n\n"
-            "Don't alter question and keywords below — insert them straight into the tool.\n"
-            f"full_question:\n\"{question}\"\n\n"
-            f"keywords_related_to_question=\"{subnode}\" "
-            "Provide an evidence-informed explanation when possible.\n"
-        )
-
-        async with httpx.AsyncClient(timeout=200) as client:
-            worker_url = f"{LLM_WORKER_URL}:{LLM_WORKER_PORT}"
-            resp = await client.post(
-                f"{worker_url}/ask",
-                json={"chat_id": "prefetch", "message": prompt},
-            )
-
-        resp.raise_for_status()
-        answer = resp.json().get("llm", "")
-        answer = strip_think(answer)
-
-        ctx["prefetched"][subnode] = answer
-
-
-        # Store prefetch result
-        ctx["prefetched"][subnode] = answer
-
-        # Auto-push if user is viewing this subnode
-        if ctx["selected_subnode"] == subnode:
-            await push_chat_message(user_id, answer)
-
-    except Exception as e:
-        print(f"[PREFETCH ERROR - {subnode}] {e}")
-
-    finally:
-        # Clean up pending entry
-        ctx["pending"].pop(subnode, subnode)
-
-
 # =====================================================
 # Graph Node Selection Endpoint
 # =====================================================
@@ -199,15 +137,15 @@ async def get_node_context(
         if not question:
             await push_chat_message(
                 user_id,
-                "You've clicked the summary node. Do you want a main summary of the three subjects: Strategic overview, Best practices and Target groups."
-                "To proceed. Ask me your question?" 
+                "Do you want to ask an question, answered by the full body of literature?"
+                "Please proceed, by asking me your question?" 
             )
         else:
             await push_chat_message(
                 user_id,
-                "You're back on the main summary. "
+                "Answer a question by using the full body of literature "
                 f"Would you like to ask a different question than: '{question}'? "
-                "**Respond with another question** or type **no** to reuse it."
+                "**Respond with another question** or type **yes** to repeat the previous question."
             )
         # If a prompt was already pending, cancel it and re-ask
         ctx["dialogue_state_asked"] = False
@@ -229,15 +167,16 @@ async def get_node_context(
             await push_chat_message(
                 user_id,
                 "You've selected subset "
-                f"{subnode}. What question do you want to ask?" 
+                f"{subnode}."
+                " Please ask me your question?"
             )
         else:
             await push_chat_message(
                 user_id,
                 "You've selected subset "
-                f"{subnode}. Would you like to ask a different question than: "
-                f"'{question}'? **Respond with another question** or type **no** "
-                "to reuse it."
+                f"{subnode}. Please ask me your question using this subset. If you want to repeat your previous question: "
+                f"`{question}`"
+                " type **yes**, otherwise **Respond with another question**."
             )
 
         await push_chat_message_stream(user_id, "done", "", subnode)

--- a/src/backend/endpoints/graph.py
+++ b/src/backend/endpoints/graph.py
@@ -8,9 +8,8 @@ from backend.utility.graph_api_models import ContextResponse
 from backend.endpoints.auth import get_current_user
 from backend.config import LLM_WORKER_URL, LLM_WORKER_PORT
 
-from src.backend.utility.chat_util import push_chat_message
-
-
+from src.backend.utility.chat_util import push_chat_message, push_chat_message_stream
+import json
 graph_router = APIRouter()
 
 
@@ -47,9 +46,11 @@ def _default_user_graph_context() -> Dict[str, Any]:
     return {
         "selected_subnode": "root",
         "latest_question": None,
+        "previous_question": None,
         "latest_keywords": [],
         "prefetched": {},   # subnode_name → llm_answer
         "pending": {},      # subnode_name → asyncio.Task
+        "dialogue_state_asked": False,
     }
 
 user_graph_contexts: DefaultDict[str, Dict[str, Any]] = defaultdict(
@@ -60,6 +61,71 @@ user_graph_contexts: DefaultDict[str, Dict[str, Any]] = defaultdict(
 # =====================================================
 # Prefetch Logic
 # =====================================================
+
+async def fetch_subnode_stream(user_id: str, question: str, subnode: str):
+    """
+    Docstring for fetch_subnode_stream
+    
+    :param user_id: Description
+    :type user_id: str
+    :param question: Description
+    :type question: str
+    :param subnode: Description
+    :type subnode: str
+    """
+    ctx = user_graph_contexts[user_id]
+
+    try:
+        if subnode == "root":
+            subnode = "Best practices || Target groups || Strategic overview"
+        synthetic_prompt = (
+            "SYSTEM META-INSTRUCTION:\n"
+            "If relevant, use the `paper_search` MCP tool to identify scientific "
+            "literature or studies relevant to the question.\n\n"
+            "Don't alter question and keywords below — insert them straight into the tool.\n"
+            f"full_question:\n\"{question}\"\n\n"
+            f"keywords_related_to_question=\"{subnode}\" "
+            "Provide an evidence-informed explanation when possible.\n"
+        )
+
+        worker_url = f"{LLM_WORKER_URL}:{LLM_WORKER_PORT}"
+        full_response = ""
+
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream(
+                "POST",
+                f"{worker_url}/ask_stream",
+                json={
+                    "chat_id": "default",
+                    "message": synthetic_prompt,
+                    "user_id": user_id,
+                },
+            ) as resp:
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+
+                    raw = line.removeprefix("data:").strip()
+
+                    if raw == "[DONE]":
+                        break
+
+                    try:
+                        payload = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+
+                    event_type = payload.get("type")
+                    event_data = payload.get("data")
+
+                    # ALSO emit chat messages for chat UI
+                    await push_chat_message_stream(user_id, event_type, event_data, subnode)
+                    full_response += event_data
+
+        ctx["prefetched"][subnode] = full_response
+        await push_chat_message_stream(user_id, "done", full_response)
+    except Exception as e:
+        print(f"[PREFETCH ERROR - {subnode}] {e}")
 
 async def prefetch_subnode(user_id: str, question: str, subnode: str):
     """
@@ -107,7 +173,7 @@ async def prefetch_subnode(user_id: str, question: str, subnode: str):
 
     finally:
         # Clean up pending entry
-        ctx["pending"].pop(subnode, None)
+        ctx["pending"].pop(subnode, subnode)
 
 
 # =====================================================
@@ -119,36 +185,62 @@ async def get_node_context(
     request: Request,
     user=Depends(get_current_user),
 ):
-    """
-    User clicked a graph node. This:
-    - updates the user's selected subnode
-    - pushes prefetch results if available
-    - returns standard KG node context to frontend
-    """
     user_id = user["sub"]
     ctx = user_graph_contexts[user_id]
     kg_data = request.app.state.kg_data
 
+    question = ctx.get("latest_question")
     # --------------------------------------------------
-    # ROOT NODE SELECTED
+    # ROOT NODE
     # --------------------------------------------------
     if node_id == 1:
         ctx["selected_subnode"] = "root"
 
-        if "root" in ctx["prefetched"]:
-            await push_chat_message(user_id, ctx["prefetched"]["root"])
+        if not question:
+            return
+
+        # If a prompt was already pending, cancel it and re-ask
+        ctx["dialogue_state_asked"] = False
+
+        await push_chat_message(
+            user_id,
+            "You're back on the main summary. "
+            f"Would you like to ask a different question than: '{question}'? "
+            "**Respond with another question** or type **no** to reuse it."
+        )
+
+        await push_chat_message_stream(user_id, "done", "", "root")
+
+        ctx["dialogue_state_asked"] = True
+        ctx["previous_question"] = question
+        return
 
     # --------------------------------------------------
-    # SUBNODE SELECTED
+    # SUBNODE
     # --------------------------------------------------
-    elif node_id in SUBNODE_MAP:
+    if node_id in SUBNODE_MAP:
         subnode = SUBNODE_MAP[node_id]
         ctx["selected_subnode"] = subnode
 
-        # Push cached prefetch result immediately
-        prefetched_answer = ctx["prefetched"].get(subnode)
-        if prefetched_answer:
-            await push_chat_message(user_id, prefetched_answer)
+        if not question:
+            return
+
+        # If a prompt was already pending, cancel it and re-ask
+        ctx["dialogue_state_asked"] = False
+
+        await push_chat_message(
+            user_id,
+            "You've selected subset "
+            f"{subnode}. Would you like to ask a different question than: "
+            f"'{question}'? **Respond with another question** or type **no** "
+            "to reuse it."
+        )
+
+        await push_chat_message_stream(user_id, "done", "", subnode)
+
+        ctx["dialogue_state_asked"] = True
+        ctx["previous_question"] = question
+        return
 
     # --------------------------------------------------
     # Knowledge Graph Lookup
@@ -172,13 +264,11 @@ async def get_node_context(
             error="not_found",
         )
 
-    # Gather edges involving this node
     edges = [
         rel for rel in kg_data.relations.values()
         if int(rel.sourceId) == node_id or int(rel.targetId) == node_id
     ]
 
-    # Gather neighbor nodes
     neighbor_ids = (
         {int(rel.sourceId) for rel in edges} |
         {int(rel.targetId) for rel in edges}

--- a/src/backend/endpoints/graph.py
+++ b/src/backend/endpoints/graph.py
@@ -197,18 +197,20 @@ async def get_node_context(
         ctx["selected_subnode"] = "root"
 
         if not question:
-            return
-
+            await push_chat_message(
+                user_id,
+                "You've clicked the summary node. Do you want a main summary of the three subjects: Strategic overview, Best practices and Target groups."
+                "To proceed. Ask me your question?" 
+            )
+        else:
+            await push_chat_message(
+                user_id,
+                "You're back on the main summary. "
+                f"Would you like to ask a different question than: '{question}'? "
+                "**Respond with another question** or type **no** to reuse it."
+            )
         # If a prompt was already pending, cancel it and re-ask
         ctx["dialogue_state_asked"] = False
-
-        await push_chat_message(
-            user_id,
-            "You're back on the main summary. "
-            f"Would you like to ask a different question than: '{question}'? "
-            "**Respond with another question** or type **no** to reuse it."
-        )
-
         await push_chat_message_stream(user_id, "done", "", "root")
 
         ctx["dialogue_state_asked"] = True
@@ -221,20 +223,22 @@ async def get_node_context(
     if node_id in SUBNODE_MAP:
         subnode = SUBNODE_MAP[node_id]
         ctx["selected_subnode"] = subnode
-
-        if not question:
-            return
-
         # If a prompt was already pending, cancel it and re-ask
         ctx["dialogue_state_asked"] = False
-
-        await push_chat_message(
-            user_id,
-            "You've selected subset "
-            f"{subnode}. Would you like to ask a different question than: "
-            f"'{question}'? **Respond with another question** or type **no** "
-            "to reuse it."
-        )
+        if not question:
+            await push_chat_message(
+                user_id,
+                "You've selected subset "
+                f"{subnode}. What question do you want to ask?" 
+            )
+        else:
+            await push_chat_message(
+                user_id,
+                "You've selected subset "
+                f"{subnode}. Would you like to ask a different question than: "
+                f"'{question}'? **Respond with another question** or type **no** "
+                "to reuse it."
+            )
 
         await push_chat_message_stream(user_id, "done", "", subnode)
 

--- a/src/backend/utility/chat_util.py
+++ b/src/backend/utility/chat_util.py
@@ -94,7 +94,7 @@ async def push_chat_message(
     payload = {
         "role": "chatbot",
         "content": message,
-        "mode": "replace", 
+        "mode": "replace",   
         "subnode": subnode,
     }
 
@@ -112,3 +112,61 @@ async def push_chat_message(
     except Exception as e:
         print(f"❌ push_chat_message ERROR for user={user_id}: {e}")
 
+
+async def push_chat_message_stream(
+    user_id: str,
+    event_type: str,
+    message: str,
+    subnode: str | None = None,
+):
+    """
+    Sends a full assistant message (non-streamed) to the user.
+    Explicitly marked as FINAL/REPLACE to avoid streaming confusion.
+    """
+    if sio is None:
+        print("⚠ push_chat_message: Socket.IO not registered")
+        return
+
+    sid = user_connections.get(user_id)
+    print(f"[PUSH] user={user_id}, sid={sid}")
+
+    if not sid:
+        return
+
+    payload = {
+        "role": "chatbot",
+        "content": message,
+        "mode": "replace", 
+        "subnode": subnode,
+    }
+
+    try:
+        if(event_type == "done"):
+            await sio.emit(
+            "done",
+            {"full_response": message},
+            to=sid,
+            )
+        # ALSO emit chat messages for chat UI
+        elif event_type == "on_chat_model_stream" and message:
+            await sio.emit(
+                "message",
+                {
+                    "role": "chatbot",
+                    "content": message,
+                },
+                to=sid,
+            )
+        else:
+            await sio.emit(
+                "event",
+                {
+                    "type": event_type,
+                    "data": message,
+                    "timestamp": payload.get("timestamp"),
+                },
+                to=sid,
+            )
+
+    except Exception as e:
+        print(f"❌ push_chat_message ERROR for user={user_id}: {e}")

--- a/src/backend/utility/chat_util.py
+++ b/src/backend/utility/chat_util.py
@@ -94,7 +94,7 @@ async def push_chat_message(
     payload = {
         "role": "chatbot",
         "content": message,
-        "mode": "replace",   # 🔥 DIT is de sleutel
+        "mode": "replace", 
         "subnode": subnode,
     }
 


### PR DESCRIPTION
As a response to the concerns described in issue #99  and #100 as well as the discussed points in the standup. Together with @raoulg and @MarijnRS, I have changed the backend for the graph and chat drastically. 

The main points that where fixed/changed:
1. The previous answers are not cached amongst sessions anymore. Now everytime you establish a new connection to the backend by visiting the kp webpage or refreshing the page. The context gets cleared and previous answers won't show up anymore.
2.  When typing in one question in the chat for the first time within a session, the subnode answers now won't get generated automatically. It will instead prompt to user, if they want to ask a new question or use the selected Target Group/Best Practices/Strategic overview with the previous question.

------
## Autogenerated

This pull request significantly refactors the chat backend to unify and improve the handling of dialogue state, question reuse, and streaming chat responses. The changes streamline how user questions and subnode selections are managed, introduce a new streaming utility for chat messages, and enhance the user experience when navigating between graph nodes and subnodes.

**Dialogue state management and chat workflow improvements:**

* Refactored the chat endpoint (`chat.py`) to unify handling of dialogue state, enabling users to easily reuse or change their last question when switching between root and subnodes. The system now prompts users to confirm or update their question and manages state flags accordingly. [[1]](diffhunk://#diff-3e41dcce11e788d9dab019deb148e876a85a0aac85209db5193d81ae3ea9325bL94-R164) [[2]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1R49-R53) [[3]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1L122-R243)
* Improved context initialization and management by setting up a default user graph context upon connection and ensuring proper updates to `latest_question`, `previous_question`, `selected_subnode`, and `dialogue_state_asked`. [[1]](diffhunk://#diff-3e41dcce11e788d9dab019deb148e876a85a0aac85209db5193d81ae3ea9325bR74) [[2]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1R49-R53)

**Streaming and event handling enhancements:**

* Introduced the `push_chat_message_stream` utility to standardize streaming and event emission to the frontend, replacing scattered `sio.emit` calls and ensuring consistent message delivery for both streamed and non-streamed events. [[1]](diffhunk://#diff-e59013cef6fdc65ee44db0928f4f115dbd7450bc69d6b40a53f1ed2ac8cabcb4R115-R172) [[2]](diffhunk://#diff-3e41dcce11e788d9dab019deb148e876a85a0aac85209db5193d81ae3ea9325bL136-L149) [[3]](diffhunk://#diff-3e41dcce11e788d9dab019deb148e876a85a0aac85209db5193d81ae3ea9325bL159-R232)
* Added the `fetch_subnode_stream` async function to enable streaming LLM responses for subnode queries, aligning subnode answer delivery with the main chat workflow.

**User experience and error handling:**

* Updated the logic for node and subnode selection in the graph endpoint to prompt users for question reuse or update, and to handle cases where no question is yet available, improving clarity and flow for the user.
* Improved error handling and messaging by ensuring errors and completion events are sent through the new streaming utility, providing more robust feedback to users. [[1]](diffhunk://#diff-3e41dcce11e788d9dab019deb148e876a85a0aac85209db5193d81ae3ea9325bL136-L149) [[2]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1R65-R129)

These changes lay the groundwork for a more interactive and user-friendly chat experience, with clearer dialogue management and more reliable streaming of assistant responses.

**References:** [[1]](diffhunk://#diff-3e41dcce11e788d9dab019deb148e876a85a0aac85209db5193d81ae3ea9325bL94-R164) [[2]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1R49-R53) [[3]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1L122-R243) [[4]](diffhunk://#diff-e59013cef6fdc65ee44db0928f4f115dbd7450bc69d6b40a53f1ed2ac8cabcb4R115-R172) [[5]](diffhunk://#diff-df112872f08d309ec8d5159e247db835f4f8b8f17455fead79b5b4f3fab7e7c1R65-R129)