### PR TITLE
fix it on windows, there were some set commands for llm_worker and mc…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ BASE_URL=http://localhost:10090 PYTHONPATH=src \
 python -m uvicorn src.backend.main:app --host 0.0.0.0 --port 10090 --reload
 """
 
-mcp_server = "PYTHONPATH=src python src/mcp_servers/main.py"
-llm_worker = "PYTHONPATH=src python src/llm_worker/main.py"
+mcp_server = 'PYTHONPATH=src python -m src.mcp_servers.main'
+llm_worker  = 'PYTHONPATH=src python -m src.llm_worker.main'
 
 # ====================================
 # macOS ARM tasks
@@ -144,8 +144,8 @@ BASE_URL=http://localhost:10090 PYTHONPATH=src \
 python -m uvicorn src.backend.main:app --host 0.0.0.0 --port 10090 --reload
 """
 
-mcp_server = "PYTHONPATH=src python src/mcp_servers/main.py"
-llm_worker = "PYTHONPATH=src python src/llm_worker/main.py"
+mcp_server = 'PYTHONPATH=src python -m src.mcp_servers.main'
+llm_worker  = 'PYTHONPATH=src python -m src.llm_worker.main'
 
 # ====================================
 # Windows (cmd.exe)
@@ -156,8 +156,9 @@ backend_no_docker = '''
 PYTHONPATH=src python -m uvicorn src.backend.main:app --host 0.0.0.0 --port 10090 --reload
 '''
 
-mcp_server = 'set PYTHONPATH=src && python src\mcp_servers\main.py'
-llm_worker  = 'set PYTHONPATH=src && python src\llm_worker\main.py'
+mcp_server = 'PYTHONPATH=src python -m src.mcp_servers.main'
+llm_worker  = 'PYTHONPATH=src python -m src.llm_worker.main'
+
 
 # ====================================
 # Pixi activation environment

--- a/src/llm_worker/main.py
+++ b/src/llm_worker/main.py
@@ -5,7 +5,7 @@ import uvicorn
 from fastapi import FastAPI
 from loguru import logger
 
-from endpoints.ask import llm_worker_router
+from .endpoints.ask import llm_worker_router
 
 
 # =====================================================


### PR DESCRIPTION
This pull request updates the way the `mcp_server` and `llm_worker` services are launched and fixes an import path in `src/llm_worker/main.py`. The main improvements are standardizing the startup commands to use Python's module execution (`-m`) and correcting a relative import for better maintainability.

Startup command improvements:

* Changed the `mcp_server` and `llm_worker` commands in `pyproject.toml` for Linux/macOS and Windows to use `python -m <module>` instead of direct script execution, which improves module resolution and consistency across environments. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L134-R135) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L147-R148) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L159-R161)

Codebase maintainability:

* Updated the import in `src/llm_worker/main.py` to use a relative path for `llm_worker_router`, ensuring proper module resolution and avoiding potential import errors.