### PR TITLE
simple log_event endpoint to log UI events in langfuse

### DIFF
--- a/src/backend/endpoints/log_event.py
+++ b/src/backend/endpoints/log_event.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from typing import Any
 from langfuse import Langfuse, get_client
@@ -27,7 +27,6 @@ async def log_event(payload: LogEventPayload, user=Depends(get_current_user)):
     langfuse = get_client()
     user_id = user.get("sub", "unknown")
     session_id = user.get("sid", user_id)
-    timestamp = datetime.now(timezone.utc)
 
     trace_id = langfuse.create_trace_id()
 

--- a/src/backend/endpoints/log_event.py
+++ b/src/backend/endpoints/log_event.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field

--- a/src/backend/endpoints/log_event.py
+++ b/src/backend/endpoints/log_event.py
@@ -1,0 +1,40 @@
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+from typing import Any
+from langfuse import Langfuse, get_client
+
+from backend.endpoints.auth import get_current_user
+
+log_event_router = APIRouter()
+
+Langfuse(
+    public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
+    secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
+    host=os.getenv("LANGFUSE_HOST"),
+)
+
+
+class LogEventPayload(BaseModel):
+    name: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+@log_event_router.post("/log_event", status_code=204)
+async def log_event(payload: LogEventPayload, user=Depends(get_current_user)):
+    langfuse = get_client()
+    user_id = user.get("sub", "unknown")
+    session_id = user.get("sid", user_id)
+    timestamp = datetime.now(timezone.utc)
+
+    trace_id = langfuse.create_trace_id()
+
+    langfuse.create_event(
+        trace_context={"trace_id": trace_id, "user_id": user_id, "session_id": session_id},
+        name=payload.name,
+        metadata=payload.metadata,
+    )
+
+    langfuse.flush()

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -10,6 +10,7 @@ from backend.endpoints.assets import asset_router, frontend, detect_frontend_dir
 from backend.endpoints.auth import auth_router
 from backend.endpoints.chat import chat_router, socket_app
 from backend.endpoints.graph import graph_router
+from backend.endpoints.log_event import log_event_router
 
 # Build list of allowed CORS origins
 cors_origins = [BASE_URL]
@@ -56,4 +57,5 @@ app.include_router(asset_router)
 app.include_router(auth_router)
 app.include_router(chat_router)
 app.include_router(graph_router)
+app.include_router(log_event_router)
 app.include_router(frontend)


### PR DESCRIPTION
text generated by AI:

## POST `/log_event` — Backend UI Event Logging

Adds a new endpoint that accepts UI events and forwards them to Langfuse.

### Endpoint
`POST /log_event` → `204 No Content`

### Request Body
- **name** *(string, required)* — Event identifier  
- **metadata** *(object, optional)* — Arbitrary event data  

### Authentication
- Session cookie (same as other endpoints)  
- User `sub` and `sid` are attached automatically via `trace_context`

### Files Changed
- `log_event.py` — New endpoint  
- `main.py` — Register router  

### Testing
- Tested manually via `curl` with Authentik session cookies  
- Confirmed `204` response  
- Verified events appearing in Langfuse (tested with production langfuse, made a new project called studio_dev since running langfuse locally is a headache)

Example of a log:

<img width="535" height="544" alt="image" src="https://github.com/user-attachments/assets/43382a13-3577-4a88-b683-8810b4775c87" />

