### PR TITLE
feat: unify Langfuse tracing to one trace per chat turn

### DIFF
--- a/scripts/run_qava_test.py
+++ b/scripts/run_qava_test.py
@@ -62,7 +62,7 @@ def main() -> int:
         run([sys.executable, "scripts/setup_authentik.py"])
 
         # 5. Wait for services
-        run(["npx", "wait-on", "tcp:8000", "tcp:10090"], cwd=tests_dir)
+        run(["npx", "wait-on", "tcp:10090", "tcp:9000"], cwd=tests_dir)
 
         # 6. Run tests
         exit_code = run(

--- a/src/backend/endpoints/chat.py
+++ b/src/backend/endpoints/chat.py
@@ -4,6 +4,7 @@ from typing import List, TypedDict, DefaultDict
 
 import socketio
 from fastapi import APIRouter
+from langfuse import get_client
 
 from backend.config import BASE_URL
 from backend.config import (
@@ -85,82 +86,121 @@ async def send_message(sid, data):
     if not user_msg:
         return
 
-    session = user_sessions.setdefault(user_id, {"history": []})
-    ctx = user_graph_contexts[user_id]
-
-    selected_subnode = ctx.get("selected_subnode", "root")
-    dialogue_state_asked = bool(ctx.get("dialogue_state_asked", False))
-    prefetched = (ctx.get("prefetched") or {}).get(selected_subnode)
-
-    if dialogue_state_asked:
-        try:
-            if user_msg.lower() == "yes":
-                # Use prefetched if available
-                if prefetched:
-                    await push_chat_message_stream(
-                        user_id,
-                        "on_chat_model_stream",
-                        prefetched,
-                        selected_subnode,
-                    )
-                    await push_chat_message_stream(
-                        user_id,
-                        "done",
-                        prefetched,
-                        selected_subnode,
-                    )
-                    return
-
-                question = ctx.get("latest_question") or ctx.get("previous_question")
-            else:
-                ctx["latest_question"] = user_msg
-                ctx["prefetched"] = {}
-                question = ctx["latest_question"]
-
-            await fetch_subnode_stream(user_id, question, selected_subnode)
-            await push_chat_message_stream(
-                user_id,
-                "done",
-                ctx.get("prefetched", {}).get(selected_subnode),
-                selected_subnode,
-            )
-            return
-
-        finally:
-            ctx["dialogue_state_asked"] = False
-
     # --------------------------------------------------
-    # NORMAL ROOT WORKFLOW (user asked a new question in chat)
+    # Create a single Langfuse trace for this chat turn
     # --------------------------------------------------
-    session["history"].append({"role": "user", "message": user_msg})
+    langfuse = get_client()
+    trace_id = langfuse.create_trace_id()
+    print(f"[TRACE] send_message trace_id={trace_id} user={user_id}")
 
-    ctx["previous_question"] = ctx.get("latest_question")
-    ctx["latest_question"] = user_msg
-    ctx["selected_subnode"] = "root"
-    ctx["dialogue_state_asked"] = False
+    with langfuse.start_as_current_observation(
+        as_type="span",
+        name="chat_turn",
+        trace_context={"trace_id": trace_id},
+    ) as root_span:
+        root_span.update_trace(
+            name="chat_turn",
+            user_id=user_id,
+            session_id=sid,
+            input={"message": user_msg},
+        )
+        root_span.update(input={"message": user_msg})
 
-    synthetic_prompt = root_question_prompt(user_msg)
+        session = user_sessions.setdefault(user_id, {"history": []})
+        ctx = user_graph_contexts[user_id]
 
-    full_response = ""
+        selected_subnode = ctx.get("selected_subnode", "root")
+        dialogue_state_asked = bool(ctx.get("dialogue_state_asked", False))
+        prefetched = (ctx.get("prefetched") or {}).get(selected_subnode)
 
-    async for evt in stream_agent_events(synthetic_prompt, user_id=user_id):
-        event_type = evt["type"]
-        event_data = evt["data"]
+        full_response = ""
 
-        if event_type != "on_chat_model_stream":
-            await push_chat_message_stream(user_id, event_type, event_data, "root")
-            continue
+        if dialogue_state_asked:
+            try:
+                if user_msg.lower() == "yes":
+                    # Use prefetched if available
+                    if prefetched:
+                        full_response = prefetched
+                        await push_chat_message_stream(
+                            user_id,
+                            "on_chat_model_stream",
+                            prefetched,
+                            selected_subnode,
+                        )
+                        await push_chat_message_stream(
+                            user_id,
+                            "done",
+                            prefetched,
+                            selected_subnode,
+                        )
+                        root_span.update(output={"response": full_response})
+                        root_span.update_trace(output={"response": full_response})
+                        langfuse.flush()
+                        return
 
-        if event_data:
-            await push_chat_message_stream(
-                user_id, "on_chat_model_stream", event_data, "root"
-            )
-            full_response += event_data
+                    question = ctx.get("latest_question") or ctx.get("previous_question")
+                else:
+                    ctx["latest_question"] = user_msg
+                    ctx["prefetched"] = {}
+                    question = ctx["latest_question"]
 
-    # --------------------------------------------------
-    # FINALIZE ROOT RESPONSE
-    # --------------------------------------------------
-    session["history"].append({"role": "assistant", "message": full_response})
-    ctx.setdefault("prefetched", {})["root"] = full_response
+                await fetch_subnode_stream(
+                    user_id, question, selected_subnode,
+                    trace_id=trace_id, session_id=sid,
+                )
+                full_response = ctx.get("prefetched", {}).get(selected_subnode, "")
+                await push_chat_message_stream(
+                    user_id,
+                    "done",
+                    full_response,
+                    selected_subnode,
+                )
+                root_span.update(output={"response": full_response})
+                root_span.update_trace(output={"response": full_response})
+                langfuse.flush()
+                return
 
-    await push_chat_message_stream(user_id, "done", full_response, "root")
+            finally:
+                ctx["dialogue_state_asked"] = False
+
+        # --------------------------------------------------
+        # NORMAL ROOT WORKFLOW (user asked a new question in chat)
+        # --------------------------------------------------
+        session["history"].append({"role": "user", "message": user_msg})
+
+        ctx["previous_question"] = ctx.get("latest_question")
+        ctx["latest_question"] = user_msg
+        ctx["selected_subnode"] = "root"
+        ctx["dialogue_state_asked"] = False
+
+        synthetic_prompt = root_question_prompt(user_msg)
+
+        async for evt in stream_agent_events(
+            synthetic_prompt, user_id=user_id, trace_id=trace_id,
+            session_id=sid,
+        ):
+            event_type = evt["type"]
+            event_data = evt["data"]
+
+            if event_type != "on_chat_model_stream":
+                await push_chat_message_stream(user_id, event_type, event_data, "root")
+                continue
+
+            if event_data:
+                await push_chat_message_stream(
+                    user_id, "on_chat_model_stream", event_data, "root"
+                )
+                full_response += event_data
+
+        # --------------------------------------------------
+        # FINALIZE ROOT RESPONSE
+        # --------------------------------------------------
+        session["history"].append({"role": "assistant", "message": full_response})
+        ctx.setdefault("prefetched", {})["root"] = full_response
+
+        root_span.update(output={"response": full_response})
+        root_span.update_trace(output={"response": full_response})
+
+        await push_chat_message_stream(user_id, "done", full_response, "root")
+
+    langfuse.flush()

--- a/src/backend/endpoints/graph.py
+++ b/src/backend/endpoints/graph.py
@@ -55,16 +55,22 @@ user_graph_contexts: DefaultDict[str, Dict[str, Any]] = defaultdict(
 # =====================================================
 
 
-async def fetch_subnode_stream(user_id: str, question: str, subnode: str):
+async def fetch_subnode_stream(
+    user_id: str,
+    question: str,
+    subnode: str,
+    trace_id: str | None = None,
+    session_id: str | None = None,
+):
     """
-    Docstring for fetch_subnode_stream
+    Stream an LLM response for a subnode question.
 
-    :param user_id: Description
-    :type user_id: str
-    :param question: Description
-    :type question: str
-    :param subnode: Description
-    :type subnode: str
+    :param user_id: Authenticated user id.
+    :param question: The user's question text.
+    :param subnode: Which subnode perspective to use.
+    :param trace_id: Optional Langfuse trace id to keep all
+        observations under a single per-turn trace.
+    :param session_id: Optional Socket.IO sid used as Langfuse session_id.
     """
     ctx = user_graph_contexts[user_id]
 
@@ -80,7 +86,10 @@ async def fetch_subnode_stream(user_id: str, question: str, subnode: str):
         full_response = ""
 
         # ← Direct generator call — no HTTP, no SSE parsing
-        async for evt in stream_agent_events(synthetic_prompt, user_id=user_id):
+        async for evt in stream_agent_events(
+            synthetic_prompt, user_id=user_id, trace_id=trace_id,
+            session_id=session_id,
+        ):
             event_type = evt["type"]
             event_data = evt["data"]
 

--- a/src/backend/endpoints/log_event.py
+++ b/src/backend/endpoints/log_event.py
@@ -1,5 +1,3 @@
-import os
-
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from typing import Any

--- a/src/backend/endpoints/log_event.py
+++ b/src/backend/endpoints/log_event.py
@@ -3,17 +3,11 @@ import os
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from typing import Any
-from langfuse import Langfuse, get_client
+from langfuse import get_client
 
 from backend.endpoints.auth import get_current_user
 
 log_event_router = APIRouter()
-
-Langfuse(
-    public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
-    secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
-    host=os.getenv("LANGFUSE_HOST"),
-)
 
 
 class LogEventPayload(BaseModel):

--- a/src/backend/utility/chat_util.py
+++ b/src/backend/utility/chat_util.py
@@ -74,27 +74,79 @@ async def _create_agent() -> MCPAgent:
         callbacks=[CallbackHandler()],
     )
 
-async def run_agent(message: str, user_id: str | None = None) -> str:
+async def run_agent(
+    message: str,
+    user_id: str | None = None,
+    trace_id: str | None = None,
+    session_id: str | None = None,
+) -> str:
     """
     Run the agent to completion and return the full response string.
+
+    When *trace_id* is supplied the entire agent execution is recorded
+    under that existing Langfuse trace (the CallbackHandler created
+    inside ``_create_agent`` automatically joins the current observation
+    context).
     """
     langfuse = get_client()
+
+    if trace_id is not None:
+        with langfuse.start_as_current_observation(
+            as_type="span",
+            name="run_agent",
+            trace_context={"trace_id": trace_id},
+        ) as span:
+            span.update_trace(user_id=user_id, session_id=session_id)
+            agent = await _create_agent()
+            result = await agent.run(message)
+        langfuse.flush()
+        return result
+
+    # Fallback: no trace_id provided — original behaviour
     agent = await _create_agent()
     try:
         return await agent.run(message)
     finally:
         langfuse.flush()
- 
 
 
 async def stream_agent_events(
-    message: str, user_id: str | None = None
+    message: str,
+    user_id: str | None = None,
+    trace_id: str | None = None,
+    session_id: str | None = None,
 ) -> AsyncGenerator[dict, None]:
     """
     Async generator that yields parsed event dicts:
       {"type": str, "data": str, "timestamp": float}
+
+    When *trace_id* is supplied the streaming execution is recorded
+    under that existing Langfuse trace.
     """
     langfuse = get_client()
+
+    if trace_id is not None:
+        with langfuse.start_as_current_observation(
+            as_type="span",
+            name="stream_agent_events",
+            trace_context={"trace_id": trace_id},
+        ) as span:
+            span.update_trace(user_id=user_id, session_id=session_id)
+            agent = await _create_agent()
+            async for event in agent.stream_events(message):
+                event_type = event.get("event", "")
+                data = ""
+                if event_type == "on_chat_model_stream":
+                    data = event["data"]["chunk"].content or ""
+                yield {
+                    "type": event_type,
+                    "data": data,
+                    "timestamp": time.time(),
+                }
+        langfuse.flush()
+        return
+
+    # Fallback: no trace_id provided — original behaviour
     agent = await _create_agent()
     try:
         async for event in agent.stream_events(message):

--- a/tests/bdd/containers/docker-compose-authentik.yml
+++ b/tests/bdd/containers/docker-compose-authentik.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_USER: authentik
       POSTGRES_DB: authentik
     networks:
-      - studio_net
+      - mcp_server_scepa_studio_net
 
   # ─── Authentik Redis ────────────────────────────────────
   authentik-redis:
@@ -34,7 +34,7 @@ services:
     volumes:
       - authentik_redis:/data
     networks:
-      - studio_net
+      - mcp_server_scepa_studio_net
 
   # ─── Authentik Server (web UI + API) ────────────────────
   authentik-server:
@@ -66,7 +66,7 @@ services:
       authentik-redis:
         condition: service_healthy
     networks:
-      - studio_net
+      - mcp_server_scepa_studio_net
 
   # ─── Authentik Worker (background tasks) ────────────────
   authentik-worker:
@@ -92,10 +92,11 @@ services:
       authentik-redis:
         condition: service_healthy
     networks:
-      - studio_net
+      - mcp_server_scepa_studio_net
 
 networks:
-  studio_net:
+  mcp_server_scepa_studio_net:
+    external: true
 
 volumes:
   authentik_database:


### PR DESCRIPTION
Description generated by AI:

## One Langfuse trace per chat turn

### Problem

A single user message produced 2–4 separate Langfuse traces because `CallbackHandler()` auto-created a new trace each time the LLM agent ran, and subnode flows spawned additional traces.

### Solution

Generate one `trace_id` at the start of `send_message` and pass it through the entire call chain:

```
send_message(sid, data)
  └─ trace_id = langfuse.create_trace_id()
       ├─ stream_agent_events(trace_id=…)
       │    └─ CallbackHandler() ← auto-joins existing trace
       └─ fetch_subnode_stream(trace_id=…)
            └─ stream_agent_events(trace_id=…)
```

Each trace includes: **name** (`chat_turn`), **input** (user message), **output** (assistant response), **user_id**, and **session_id**.

### Other changes

- Authentik compose now shares `mcp_server_scepa_studio_net` with the backend
- `run_qava_test.py` creates external networks before compose up and waits on correct ports

### Example trace
Link: https://scepadeploy.mads-han.src.surf-hosted.nl/project/cmn0f1gik000lph07z9kjmflt/traces?peek=c3ebe0c2cbd79c4cc34ac6e1b9c63771&timestamp=2026-04-09T12%3A06%3A44.890Z&observation=trace-c3ebe0c2cbd79c4cc34ac6e1b9c63771
<img width="1132" height="857" alt="image" src="https://github.com/user-attachments/assets/4545a7a9-e2ff-47a3-bc8a-c96b55ff52f9" />


<!-- Paste a Langfuse screenshot here -->

### Changed files

- `src/backend/endpoints/chat.py`
- `src/backend/utility/chat_util.py`
- `src/backend/endpoints/graph.py`
- `tests/bdd/containers/docker-compose-authentik.yml`
- `scripts/run_qava_test.py`
